### PR TITLE
Upgrade Django to 3.2.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'cached_property',
-        'django==3.2.14',
+        'django==3.2.15',
         'django-mptt~=0.13.4',
         'jsonschema',
         'six',


### PR DESCRIPTION
Upgrades Django to address [Reflected File Download](https://github.com/fecgov/fec-eregs/issues/703). 

Related PRs against other branches:

repo | branch | PR
------ | ------ | ------
fec-eregs | feature/703-django-vulnerability | [eregs #705](https://github.com/fecgov/fec-eregs/pull/705)
regulations-core | django-to-3.2.15 | core #6
regulations-parser | django-3.2.14-=>-3.2.15 | [parser #7](https://github.com/fecgov/regulations-parser/pull/7)
regulations-site | upgrade-django-3.2.15 | [site #6](https://github.com/fecgov/regulations-site/pull/6)

